### PR TITLE
feat: improve package generation process

### DIFF
--- a/Fluent-Random-Picker/Fluent-Random-Picker.csproj
+++ b/Fluent-Random-Picker/Fluent-Random-Picker.csproj
@@ -74,8 +74,8 @@ Probabilities can be specified, values can be weighted, ...</Description>
 
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="5.9.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Fluent-Random-Picker/Fluent-Random-Picker.csproj
+++ b/Fluent-Random-Picker/Fluent-Random-Picker.csproj
@@ -11,7 +11,13 @@
 Probabilities can be specified, values can be weighted, ...</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SynchReleaseVersion>true</SynchReleaseVersion>
-    <ReleaseVersion>2.0.0</ReleaseVersion> <!-- change version in solution options! -->
+
+    <LibraryVersion>2.1.0</LibraryVersion> <!-- change version in solution options! -->
+    <PackageReleaseNotes>Alpha Release</PackageReleaseNotes>
+    <VersionPrefix>$(LibraryVersion)</VersionPrefix>
+    <AssemblyVersion>$(LibraryVersion)</AssemblyVersion>
+    <FileVersion>$(LibraryVersion)</FileVersion>
+    <ReleaseVersion>$(LibraryVersion)</ReleaseVersion> 
   </PropertyGroup>
 
   <PropertyGroup>
@@ -33,7 +39,13 @@ Probabilities can be specified, values can be weighted, ...</Description>
     <PackageTags>random;fluent;picker;choice;pick;probability;outof;choose</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/ndsvw/Fluent-Random-Picker</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <Title>Fluent Random Picker</Title>
+
+    <!-- Creates separate package with symbol files -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
   </PropertyGroup>
 
   <ItemGroup>
@@ -51,6 +63,15 @@ Probabilities can be specified, values can be weighted, ...</Description>
     <None Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <PropertyGroup Label="Release (ci-cd) nuget settings" Condition="'$(Configuration)' == 'Release'">
+    <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#continuousintegrationbuild -->
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#deterministicsourcepaths -->
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
+    <!-- Embeds files created/compile during build process (like AssemblyInfo) in final package. Required if you want to have all green marks in nuget package explorer program (https://github.com/dotnet/sourcelink/blob/main/docs/README.md#embeduntrackedsources)  -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="5.9.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
@@ -60,6 +81,11 @@ Probabilities can be specified, values can be weighted, ...</Description>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup Label="Source link - dev only asset. It adds source link (https://github.com/dotnet/sourcelink) capabilities to the nuget package.">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <InternalsVisibleTo Include="Fluent-Random-Picker-Tests" />


### PR DESCRIPTION
Hello,

First of all you made great work with .csproj and all settings related to creating nuget package :). As this is your first package I can say 1 thing - **GREAT** work. When I read that it is someone's first nuget package then I thought it's going to be very messy with .nuspec and other old things, however it was not :).

I made following changes in this PR:
- Made 1 variable to set assembly/file and package version (version-prefix). Previously file version and assembly version were marked as 1.0.0. I think it is best to keep all those versions in sync and do not introduce the same mess that .Net Framework had with versioning (3 different versioning schemes for file/assembly/nuget package).
  - Before (notice that nuget package has 2.0 version and file/assembly does not!)

![image](https://user-images.githubusercontent.com/3819892/123561103-e1eed200-d7a6-11eb-944b-f5da3cc58f6f.png)
![image](https://user-images.githubusercontent.com/3819892/123561112-e9ae7680-d7a6-11eb-8a75-302056166620.png)
  - After: 
![image](https://user-images.githubusercontent.com/3819892/123561132-08ad0880-d7a7-11eb-9c0a-550b01c793e5.png)
![image](https://user-images.githubusercontent.com/3819892/123561322-f2ec1300-d7a7-11eb-9e95-42d990d145e4.png)

- Repository URL is published with the package info. Previously there was some info about generic nuget M$ repo from what I saw. Right now it should normally show your repo when looking on your package.
- During packaging process an additional file .snupkg is being created. It contains symbols used during debugging process. It does not harm to add them to nuget symbolic repository to give more tools to devs using your tool I think :). 
- Enables `ContinuousIntegrationBuild` during release build. It turns on a lot of interesting switches that makes your package more friendly/better to use. 


Nuget package info before:
![image](https://user-images.githubusercontent.com/3819892/123561374-4e1e0580-d7a8-11eb-9b11-e0cf2a81c356.png)
Nuget package info after with this PR:
![image](https://user-images.githubusercontent.com/3819892/123561387-58d89a80-d7a8-11eb-874b-6afe6b69dea2.png)


I also saw 2 interesting project properties : `ReleaseVersion` and `SynchReleaseVersion`. What do they do? I never encountered them and google search only returns 2 page of results from other repos. I am curious whether (and how) it is used.