### PR TITLE
Fix Pick() returning the same value multiple times

### DIFF
--- a/FluentRandomPicker.Tests/PrioritizedElementsTests.cs
+++ b/FluentRandomPicker.Tests/PrioritizedElementsTests.cs
@@ -43,6 +43,27 @@ public class PrioritizedElementsTests
 
         Assert.That.ProbabilitiesMatter(pickable, valueChancesPairs: valueChancesPairs);
     }
+    
+    [TestMethod]
+    public void Weight3ValuesWith3DifferentWeights_PickN_WeightsMatter()
+    {
+        var elements = new PrioritizedElement<char>[]
+        {
+            new PrioritizedElement<char> {Value = 'a', Priority = 7},
+            new PrioritizedElement<char> {Value = 'b', Priority = 2},
+            new PrioritizedElement<char> {Value = 'c', Priority = 1},
+        };
+
+        var pickable = Out.Of()
+            .PrioritizedElements(elements)
+            .WithValueSelector(x => x.Value)
+            .AndWeightSelector(x => x.Priority);
+
+        var valueChancesPairs = new[] { ('a', 0.7), ('b', 0.2), ('c', 0.1) };
+
+        Assert.That.PickNProbabilitiesMatter(pickable, valueChancesPairs: valueChancesPairs);
+    }
+
 
     [TestMethod]
     public void Percentage3ValuesWith3DifferentPercentages_PercentagesMatter()

--- a/FluentRandomPicker.Tests/TestUtils.cs
+++ b/FluentRandomPicker.Tests/TestUtils.cs
@@ -46,4 +46,27 @@ public static class TestUtils
             Assert.IsTrue(occurrences[value] <= tries * chance * (1 + acceptedDeviation));
         }
     }
+
+    public static void PickNProbabilitiesMatter<T>(this Assert _, IPick<T> pickable, int tries = 1_000_000,
+        double acceptedDeviation = 0.25, params (T value, double chance)[] valueChancesPairs)
+    {
+        var occurrences = new Dictionary<T, long>(valueChancesPairs.Length);
+
+        foreach (T value in pickable.Pick(tries))
+        {
+            if (occurrences.ContainsKey(value))
+                occurrences[value]++;
+            else
+                occurrences.Add(value, 1);
+        }
+
+        foreach(var (value, chance) in valueChancesPairs)
+        {
+            if (chance == 0 && !occurrences.ContainsKey(value))
+                continue;
+
+            Assert.IsTrue(occurrences[value] >= tries * chance * (1 - acceptedDeviation));
+            Assert.IsTrue(occurrences[value] <= tries * chance * (1 + acceptedDeviation));
+        }
+    }
 }

--- a/FluentRandomPicker/Picker/DefaultPicker.cs
+++ b/FluentRandomPicker/Picker/DefaultPicker.cs
@@ -50,23 +50,33 @@ internal sealed class DefaultPicker<T> : IPicker<IEnumerable<T>>
             return new PickResult<IEnumerable<T>>(Enumerable.Empty<T>());
 
         var prioritySum = _pairs.Sum(v => (long)v.Priority);
-        var values = Enumerable.Repeat(PickPrioritized(prioritySum), _numberOfElementsToPick);
+        var values = PickPrioritized(prioritySum);
         return new PickResult<IEnumerable<T>>(values);
     }
 
-    private T PickPrioritized(long prioritySum)
+    private IEnumerable<T> PickPrioritized(long prioritySum)
     {
-        var n = (long)(_rng.NextDouble() * prioritySum);
-
-        long localSum = 0;
-        foreach (var pair in _pairs)
+        for (var i = 0; i < _numberOfElementsToPick; i++)
         {
-            localSum += pair.Priority;
-
-            if (localSum >= n + 1)
-                return pair.Value;
+            yield return GetValue();
         }
 
-        throw new ArgumentException("Sum of priorities was wrong", nameof(prioritySum));
+        yield break;
+
+        T GetValue()
+        {
+            var n = (long)(_rng.NextDouble() * prioritySum);
+
+            long localSum = 0;
+            foreach (var pair in _pairs)
+            {
+                localSum += pair.Priority;
+
+                if (localSum >= n + 1)
+                    return pair.Value;
+            }
+
+            throw new ArgumentException("Sum of priorities was wrong", nameof(prioritySum));
+        }
     }
 }


### PR DESCRIPTION
Closes #62 

The cause behind this seems to have been the use of `Enumerable.Repeat` in `DefaultPicker`, which called `PickPrioritized` once and repeated the result multiple times.

A few questions from me before I consider this completely ready for review:
- Would it be worth testing `Pick` against other pickers; I believe if the bug was in `DefaultPicker` the issue may have been more widespread than #62 describes (but haven't tested yet).
- Copy-pasting the `ProbabilitiesMatter` assertion is a bit clunky, maybe it would be better to pass in the dict of random data?